### PR TITLE
add azcopy options

### DIFF
--- a/AzureStorageUpload/AzureStorageUpload.ps1
+++ b/AzureStorageUpload/AzureStorageUpload.ps1
@@ -1,11 +1,11 @@
 [CmdletBinding()]
 param()
 
-Function FileUpload($Source, $Pattern, $Dest, $DestKey) {    
+Function FileUpload($Source, $Pattern, $Dest, $DestKey, $AdditionalOptions) {    
 
     # Begin Upload
     Write-Output "Uploading $source/$pattern"
-    & "$PSScriptRoot\AzCopy\AzCopy.exe" /Source:$source /Dest:$Dest /DestKey:$DestKey /Pattern:$Pattern
+    & "$PSScriptRoot\AzCopy\AzCopy.exe" /Source:$source /Dest:$Dest /DestKey:$DestKey /Pattern:$Pattern $AdditionalOptions
 }
 
 Trace-VstsEnteringInvocation $MyInvocation
@@ -16,9 +16,10 @@ Try {
     $Pattern = Get-VstsInput -Name Pattern -Require
     $Dest = Get-VstsInput -Name Dest
     $DestKey = Get-VstsInput -Name DestKey    
+    $AdditionalOptions = Get-VstsInput -Name AdditionalOptions
 
     write-output "Running file Upload"
-    FileUpload $Source $Pattern $Dest $DestKey
+    FileUpload $Source $Pattern $Dest $DestKey $AdditionalOptions
 }
 Catch{
     Write-Error $_.Exception.ToString()

--- a/AzureStorageUpload/task.json
+++ b/AzureStorageUpload/task.json
@@ -47,7 +47,14 @@
             "defaultValue": "$(SecretKey)",
             "required": true,
             "helpMarkDown": "Key to the specified storage location. I recommend using a secret build variable: https://www.visualstudio.com/en-us/docs/build/define/variables#secret-variables"
-        }
+        },
+        {
+            "name": "AdditionalOptions",
+            "type": "string",
+            "label": "Key",
+            "required": false,
+            "helpMarkDown": "Add additional options for azcopy like /SetContentType"
+	}
     ],
     "instanceNameFormat":  "Upload file Azure Storage",
 	"execution":  {

--- a/AzureStorageUpload/task.json
+++ b/AzureStorageUpload/task.json
@@ -51,7 +51,7 @@
         {
             "name": "AdditionalOptions",
             "type": "string",
-            "label": "Key",
+            "label": "Additional Options",
             "required": false,
             "helpMarkDown": "Add additional options for azcopy like /SetContentType"
 	}


### PR DESCRIPTION
Need to run /SetContentType, and there was no way to provide this (and other) options. This is a generic catch all. See https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy - much like the  way the built in VSTS build task "Azure File Copy" allows for "AdditionalArguments" - not sure if this code will work as is - to see how it's used in that step, see here: https://github.com/Microsoft/vsts-tasks/blob/e193259a0063a6506ed42177cf61b95084e626be/Tasks/AzureFileCopyV2/Utility.ps1

Thanks.